### PR TITLE
Update landing page with Rabbit Consumer information

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.paddypowerbetfair"
 
 name := "rabbitmq-client"
 
-version := "1.0.1"
+version := "1.0.2-SNAPSHOT"
 
 scalaVersion := "2.12.4"
 


### PR DESCRIPTION
Adding basic info to README.md describing how to consume from a rabbitmq queue.

This is a very basic sample but it's an improvement on the `coming soon` message.

I have another branch in the works which adds actual sample apps for Publishing and Consuming.  The samples apps are complete but I'm having trouble integrating them into our `build.sbt` file.  
 