### PR TITLE
Adding basic publisher and consumer code examples 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: scala
 scala:
-- 2.12.3
+- 2.12.4
 matrix:
   include:
   - jdk: oraclejdk8
-    scala: 2.12.3
+    scala: 2.12.4
     env: COMMAND=ci-all PUBLISH=true
 script:
 - sbt -J-Xmx6144m ++$TRAVIS_SCALA_VERSION $COMMAND

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.paddypowerbetfair"
 
 name := "rabbitmq-client"
 
-version := "1.0.1"
+version := "1.0.2-SNAPSHOT"
 
 scalaVersion := "2.12.4"
 

--- a/src/samples/basicsample/BasicSampleApp.scala
+++ b/src/samples/basicsample/BasicSampleApp.scala
@@ -1,0 +1,54 @@
+package com.paddypowerbetfair.rabbitmq.basicsample
+
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.pattern.ask
+import akka.util.Timeout
+import com.paddypowerbetfair.rabbitmq._
+import com.rabbitmq.client.AMQP.BasicProperties
+import com.rabbitmq.client.Address
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+
+object BasicSampleApp extends App {
+
+  val logger = LoggerFactory.getLogger(BasicSampleApp.getClass)
+  val addresses: List[com.rabbitmq.client.Address] = List(new Address("localhost", 5672))
+
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val timeout: Timeout = Timeout(5.seconds)
+
+  val connectionFactory = new com.rabbitmq.client.ConnectionFactory()
+
+  val rabbitActor: ActorRef = system.actorOf(Props(new RabbitMqActor(connectionFactory, addresses)), "rabbitActor")
+
+  val myPublishingActor: ActorRef = system.actorOf(MyPublishingActor.props)
+  val myConsumingActor: ActorRef = system.actorOf(MyConsumingActor.props)
+
+  val headers = Map.empty[String, AnyRef]
+  val noRoutingKey = ""
+
+  val mqPropertiesBuilder: BasicProperties.Builder = new BasicProperties.Builder().contentType("application/json")
+
+  val publish = BasicPublish(
+    "myExchange",
+    noRoutingKey,
+    mqPropertiesBuilder.headers(headers.asJava).build(),
+    """{"key", :value"}""".getBytes("UTF-8")
+  )
+
+  rabbitActor ! RegisterPublisher(myPublishingActor, declarations = Nil, publisherConfirms = true)
+
+  rabbitActor ! RegisterConsumer("myQueue", myConsumingActor, List.empty[Declaration])
+
+  myPublishingActor ? publish onComplete {
+    case Success(msg) =>
+      logger.info(s"Message successfully published - $msg")
+    case Failure(th) =>
+      logger.error("Oops", th)
+  }
+}

--- a/src/samples/basicsample/MyConsumingActor.scala
+++ b/src/samples/basicsample/MyConsumingActor.scala
@@ -1,0 +1,17 @@
+package com.paddypowerbetfair.rabbitmq.basicsample
+
+import akka.actor.{Actor, ActorLogging, Props}
+import com.paddypowerbetfair.rabbitmq.{Ack, Delivery}
+
+object MyConsumingActor {
+  def props: Props = Props(new MyConsumingActor())
+}
+
+class MyConsumingActor extends Actor with ActorLogging {
+  override def receive: Receive = {
+    case d: Delivery =>
+      log.info(s"Message successfully consumed - ${d.body.map(_.toChar).mkString}")
+      sender() ! Ack
+      context.system.terminate()
+  }
+}

--- a/src/samples/basicsample/MyPublishingActor.scala
+++ b/src/samples/basicsample/MyPublishingActor.scala
@@ -1,0 +1,31 @@
+
+package com.paddypowerbetfair.rabbitmq.basicsample
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Stash}
+import com.paddypowerbetfair.rabbitmq.{BasicPublish, PublisherChannelActor}
+
+object MyPublishingActor {
+
+  def props: Props = Props(new MyPublishingActor())
+}
+
+
+
+class MyPublishingActor extends Actor with ActorLogging with Stash {
+
+  def receive: Receive = {
+    case PublisherChannelActor(rabbitPublisher) =>
+      unstashAll()
+      context.become(readyToPublish(rabbitPublisher))
+
+    case _ => stash()
+  }
+
+
+  def readyToPublish(publisher: ActorRef): Receive = {
+    case msg: BasicPublish =>
+      publisher ! msg
+      sender() ! s"Message Published - $msg"
+  }
+
+}


### PR DESCRIPTION

Added `rabbitmq-client-samples` folder which contains a very simple example for a rabbit publisher and a rabbit consumer.

